### PR TITLE
fix crash bug

### DIFF
--- a/xray/process.go
+++ b/xray/process.go
@@ -252,6 +252,9 @@ func (p *process) GetTraffic(reset bool) ([]*Traffic, error) {
 	traffics := make([]*Traffic, 0)
 	for _, stat := range resp.GetStat() {
 		matchs := trafficRegex.FindStringSubmatch(stat.Name)
+		if len(matchs) < 4 {
+			continue
+		}
 		isInbound := matchs[1] == "inbound"
 		tag := matchs[2]
 		isDown := matchs[3] == "downlink"


### PR DESCRIPTION
fix this bug:
goroutine 97 [running]:
panic: runtime error: index out of range [1] with length 0
x-ui/xray.(*process).GetTraffic(0xc0006be0f0?, 0x1)
	x-ui/xray/process.go:265 +0x7e9
x-ui/web/service.(*XrayService).GetXrayTraffic(0x40da7d?)
	x-ui/web/service/xray.go:88 +0x4e
x-ui/web/job.(*XrayTrafficJob).Run(0x1cf6118)
	x-ui/web/job/xray_traffic_job.go:21 +0x5f
github.com/robfig/cron/v3.(*Cron).startJob.func1()
	github.com/robfig/cron/v3@v3.0.1/cron.go:312 +0x6a
created by github.com/robfig/cron/v3.(*Cron).startJob
	github.com/robfig/cron/v3@v3.0.1/cron.go:310 +0xad
